### PR TITLE
语音开关+语音gui配置+背景图像正则表达式提取优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@
 *.ttf
 *.bat
 *.rpyc
+*.tmp
 uv.lock
 gui.rpy
 config.toml
+cache/
 .vscode/
 audio/
 gui/
@@ -18,3 +20,4 @@ saves/
 speaker_audio/
 talk/
 tl/
+font/

--- a/game_generator.py
+++ b/game_generator.py
@@ -36,6 +36,7 @@ class GameGenerator:
         # 云端/本地生成开关
         self.if_cloud_image = config.get('AI绘画', {}).get('if_cloud', False)
         self.if_cloud_audio = config.get('SOVITS', {}).get('if_cloud', False)
+        self.if_generate_audio = config.get('SOVITS', {}).get('if_on', True)
         self.prompts_manager = PromptsManager(config_path)
         self.game_directory = os.getcwd()
         self.images_directory = os.path.join(self.game_directory, "images")
@@ -140,7 +141,7 @@ class GameGenerator:
                 }
 
         # 移除文本中的地点标记并统一冒号
-        text_for_dialogue = re.sub(r'\[[^\[\]]+\]', '', line).strip().replace("：", ":")
+        text_for_dialogue = re.sub(r'\[.*?\]', '', line).strip().replace("：", ":")
 
         # 2. 角色和对话文本解析
         if ":" not in text_for_dialogue:
@@ -231,16 +232,17 @@ class GameGenerator:
 
                 # 生成音频
                 generated_audio_filename = ""
-                if character and character in self.character_list:
-                    audio_speaker_id = self.character_list.index(character) + 1
-                    audio_base_filename = f"audio_{next_audio_id}"
-                    next_audio_id += 1
-                    # 支持云端/本地音频生成
-                    if self.if_cloud_audio:
-                        online_generate_audio(text_no_description, audio_speaker_id, audio_base_filename)
-                    else:
-                        generate_audio(text_no_description, audio_speaker_id, audio_base_filename)
-                    generated_audio_filename = f"{audio_base_filename}.wav"
+                if self.if_generate_audio:
+                    if character and character in self.character_list:
+                        audio_speaker_id = self.character_list.index(character) + 1
+                        audio_base_filename = f"audio_{next_audio_id}"
+                        next_audio_id += 1
+                        # 支持云端/本地音频生成
+                        if self.if_cloud_audio:
+                            online_generate_audio(text_no_description, audio_speaker_id, audio_base_filename)
+                        else:
+                            generate_audio(text_no_description, audio_speaker_id, audio_base_filename)
+                        generated_audio_filename = f"{audio_base_filename}.wav"
 
                 # 添加对话记录，使用在处理此行时确定的当前背景
                 self.add_dialogue(character, text_no_location, self.current_background_name, generated_audio_filename)

--- a/gui.py
+++ b/gui.py
@@ -7,17 +7,14 @@ import os
 import shutil
 import sys
 import webbrowser
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, urlencode
 import requests
 from PyQt5.QtCore import QThread, pyqtSignal, QTimer, Qt, QSize
 from PyQt5.QtGui import QIcon, QTextCursor, QPixmap
 from PyQt5.QtWidgets import QApplication, QFileDialog, QVBoxLayout, QHBoxLayout, QWidget,  QSizePolicy, QGridLayout
-from qfluentwidgets import (NavigationItemPosition, LineEdit, TitleLabel, TogglePushButton, TransparentToolButton, ComboBox, PushButton, FluentIcon, Theme, setTheme, InfoBar, InfoBarPosition, HyperlinkCard, HorizontalFlipView, PrimaryPushButton, StrongBodyLabel, HyperlinkButton, PasswordLineEdit, FluentWindow, Dialog, IndeterminateProgressBar, MessageBoxBase, SubtitleLabel, SwitchSettingCard, TextEdit, PrimaryPushSettingCard, SingleDirectionScrollArea, CardWidget, theme,Action)
+from qfluentwidgets import (NavigationItemPosition, LineEdit, TitleLabel, TogglePushButton, TransparentToolButton, ComboBox, PushButton, FluentIcon, Theme, setTheme, InfoBar, InfoBarPosition, HyperlinkCard, HorizontalFlipView, PrimaryPushButton, StrongBodyLabel, HyperlinkButton, PasswordLineEdit, FluentWindow, Dialog, IndeterminateProgressBar, MessageBoxBase, SubtitleLabel, SwitchSettingCard, TextEdit, PrimaryPushSettingCard, SingleDirectionScrollArea, CardWidget, theme)
 import update
 import subprocess
-from GPT import gpt
-from local_image_generator import generate_image
-from local_vocal_generator import generate_audio
 import zipfile
 import toml
 
@@ -193,7 +190,8 @@ class MainWindow(FluentWindow):
         sovits_url = "http://127.0.0.1:9880/"
         comfyui_url = "http://127.0.0.1:8188/"
 
-        if not self.config.get('SOVITS', {}).get('if_cloud', False):
+        sovits_config = self.config.get('SOVITS', {})
+        if sovits_config.get('if_on', True) and not sovits_config.get('if_cloud', False):
             if not self.check_web_port(sovits_url):
                 InfoBar.error('本地语音服务出错', "请检查是否已开启本地语音服务", orient=Qt.Vertical, position=InfoBarPosition.BOTTOM_LEFT, duration=-1, parent=self)
                 return
@@ -239,22 +237,30 @@ class MainWindow(FluentWindow):
         input_field2.setText(outline_path)
         input_field2.setMinimumHeight(40)
         input_field2.textChanged.connect(lambda: self.save_config('剧情', 'outline', input_field2.text()))
-        action1 = Action(FluentIcon.FOLDER_ADD, "", triggered=lambda: self.openFileDialog(input_field2, "文本文件 (*.txt)"))
-        input_field2.addAction(action1, LineEdit.TrailingPosition)
+
+        button = TransparentToolButton(FluentIcon.FOLDER_ADD)
+        button.setMinimumSize(50, 40)
+        button.clicked.connect(lambda: self.openFileDialog(input_field2, "文本文件 (*.txt)"))
+
+        h_layout = QHBoxLayout()
+        h_layout.addWidget(input_field2)
+        h_layout.addWidget(button)
 
         comboBox = ComboBox()
         items = ['中文', '英文', '日文']
-        comboBox.setMinimumHeight(40)
         comboBox.addItems(items)
         if theme_language in items:
             comboBox.setCurrentIndex(items.index(theme_language))
         comboBox.currentIndexChanged.connect(lambda idx: self.save_config('剧情', 'Language', items[idx]))
 
-        input_layout.addWidget(comboBox)
+        input_layout = QVBoxLayout()
+        input_layout.setSpacing(40)
+        input_layout.setContentsMargins(10, 10, 10, 10)
         input_layout.addWidget(input_field1)
-        input_layout.addWidget(input_field2)
+        input_layout.addLayout(h_layout)
 
         layout.addWidget(title_label)
+        layout.addWidget(comboBox)
         layout.addLayout(input_layout)
         return page
 
@@ -642,7 +648,7 @@ class MainWindow(FluentWindow):
         toggle_button2.toggled.connect(lambda checked: self.save_config('AI绘画', 'if_ComfyUI', checked))
 
         input_field4 = LineEdit(page)
-        input_field4.setPlaceholderText("comfyui路径")
+        input_field4.setPlaceholderText("comfyui路径(可不填，默认127.0.0.1:8188)")
         input_field4.setText(comfyui_address)
 
         input_field1 = PasswordLineEdit(page)
@@ -689,27 +695,21 @@ class MainWindow(FluentWindow):
         title_label = TitleLabel(f"{title} 页面", page)
         title_label.setStyleSheet("font-size: 24px; margin: 10px;")
 
+        # --- 读取整个 SOVITS 配置区 ---
         sovits_config = self.config.get('SOVITS', {})
         if_cloud = sovits_config.get('if_cloud', False)
         api_key = sovits_config.get('api_key', '')
-        version = sovits_config.get('version', 0)
+        if_on = sovits_config.get('if_on', True) 
 
+        # --- 顶部控件 ---
         toggle_button = TogglePushButton('云端模式', self, FluentIcon.CLOUD)
         toggle_button.setChecked(if_cloud)
         toggle_button.toggled.connect(lambda checked: self.save_config('SOVITS', 'if_cloud', checked))
 
-        comboBox = ComboBox()
-        items = ['V1', 'V2']
-        comboBox.addItems(items)
-        comboBox.setCurrentIndex(version)
-        comboBox.currentIndexChanged.connect(lambda index: self.save_config('SOVITS', 'version', index))
-
         help_button = HyperlinkButton(FluentIcon.HELP, "https://tamikip.github.io/AI-GAL-doc/", "帮助")
 
         header_layout = QHBoxLayout()
-        header_layout.setAlignment(Qt.AlignLeft)
         header_layout.addWidget(toggle_button)
-        header_layout.addWidget(comboBox)
         header_layout.addStretch(1)
         header_layout.addWidget(help_button)
 
@@ -719,33 +719,60 @@ class MainWindow(FluentWindow):
         api_key_input.setMinimumHeight(40)
         api_key_input.textChanged.connect(lambda text: self.save_config('SOVITS', 'api_key', text))
 
+        # --- 添加启用语音的开关 ---
+        voice_toggle_card = SwitchSettingCard(
+            FluentIcon.MICROPHONE,
+            "启用语音",
+            "是否在游戏中生成角色语音",
+            parent=page
+        )
+        voice_toggle_card.setChecked(if_on)
+        voice_toggle_card.checkedChanged.connect(
+            lambda checked: self.save_config('SOVITS', 'if_on', checked)
+        )
+
         layout.addWidget(title_label)
         layout.addLayout(header_layout)
         layout.addWidget(api_key_input)
+        layout.addWidget(voice_toggle_card)
 
+        # --- 动态模型输入区 ---
         input_layout = QVBoxLayout()
-        input_layout.setSpacing(20)
+        input_layout.setSpacing(15)
         input_layout.setContentsMargins(0, 10, 0, 10)
 
+        models = sovits_config.get('models', [])
         placeholders = ["男主", "女主1", "女主2", "女主3", "女主4", "女主5"]
-        for i in range(6):
-            h_layout = QHBoxLayout()
-            model_key = f'model{i + 1}'
-            url_key = f'sovits_url{i + 1}'
-            
-            model_name = sovits_config.get(model_key, '')
-            url = sovits_config.get(url_key, '')
 
-            parsed_url = urlparse(url)
+        def get_url_param(url, param_name):
+            try:
+                return parse_qs(urlparse(url).query).get(param_name, [''])[0]
+            except (AttributeError, IndexError):
+                return ''
+
+        def update_url_param(original_url, param_name, new_value):
+            parsed_url = urlparse(original_url or 'http://127.0.0.1:9880/tts?')
             query_params = parse_qs(parsed_url.query)
-            ref_audio = query_params.get("refer_audio_path", [''])[0]
-            prompt_text = query_params.get("prompt_text", [''])[0]
+            query_params[param_name] = [new_value]
+            if 'prompt_language' not in query_params:
+                query_params['prompt_language'] = ['zh']
+            new_query = urlencode(query_params, doseq=True)
+            return parsed_url._replace(query=new_query).geturl()
 
+        for i, model_data in enumerate(models):
+            h_layout = QHBoxLayout()
+            
+            model_name = model_data.get('name', '')
+            url = model_data.get('url', '')
+            
+            ref_audio = get_url_param(url, 'ref_audio_path')
+            prompt_text = get_url_param(url, 'prompt_text')
+            
             ref_audio_input = LineEdit(page)
-            ref_audio_input.setPlaceholderText(f"{placeholders[i]}参考音频")
+            ref_audio_input.setPlaceholderText(f"{placeholders[i]} 参考音频")
             ref_audio_input.setText(ref_audio)
             ref_audio_input.setReadOnly(True)
-            
+
             file_button = TransparentToolButton(FluentIcon.FOLDER_ADD)
             file_button.clicked.connect(lambda _, le=ref_audio_input: self.openFileDialog(le, "音频文件 (*.mp3 *.wav)"))
 
@@ -757,17 +784,24 @@ class MainWindow(FluentWindow):
             model_input.setPlaceholderText("模型名称(本地)")
             model_input.setText(model_name)
 
-            for widget in [ref_audio_input, prompt_input, model_input]:
+            for widget in [ref_audio_input, prompt_input, model_input, file_button]:
                 widget.setMinimumHeight(40)
 
-            def on_text_changed(le_ref, le_prompt, le_model, url_k, model_k):
-                new_url = f"http://127.0.0.1:9880/tts?refer_audio_path={le_ref.text()}&prompt_text={le_prompt.text()}&prompt_language=zh"
-                self.save_config('SOVITS', url_k, new_url)
-                self.save_config('SOVITS', model_k, le_model.text())
+            def save_and_update_config():
+                self.save_config('SOVITS', 'models', models)
 
-            ref_audio_input.textChanged.connect(lambda: on_text_changed(ref_audio_input, prompt_input, model_input, url_key, model_key))
-            prompt_input.textChanged.connect(lambda: on_text_changed(ref_audio_input, prompt_input, model_input, url_key, model_key))
-            model_input.textChanged.connect(lambda: on_text_changed(ref_audio_input, prompt_input, model_input, url_key, model_key))
+            ref_audio_input.textChanged.connect(lambda text, i=i: [
+                models[i].update({'url': update_url_param(models[i].get('url'), 'ref_audio_path', text)}),
+                save_and_update_config()
+            ])
+            prompt_input.textChanged.connect(lambda text, i=i: [
+                models[i].update({'url': update_url_param(models[i].get('url'), 'prompt_text', text)}),
+                save_and_update_config()
+            ])
+            model_input.textChanged.connect(lambda text, i=i: [
+                models[i].update({'name': text}),
+                save_and_update_config()
+            ])
 
             h_layout.addWidget(ref_audio_input, 2)
             h_layout.addWidget(file_button)

--- a/local_image_generator.py
+++ b/local_image_generator.py
@@ -1,8 +1,4 @@
-# 1. 结构更清晰：分离了下载、提交任务、历史查询等功能，易于维护和扩展。
-# 2. 将comfyui和stablediffusion单独模块化，结构更加清晰。
-# 3. 健壮性提升：增加异常处理，图片命名防止覆盖，流程更易追踪。
-# 4. 代码更简洁：删除无用依赖和复杂流程，便于理解和后续开发。
-# 5. 自动创建图片目录，提升兼容性。
+# 基于sana的1秒生成图片的本地版本，插件参考https://github.com/abelxiaoxing/ComfyUI_Sana
 import requests
 import os
 import json
@@ -103,11 +99,11 @@ def ComfyUI_generate_image(prompt, image_name, mode):
     with open(workflow_path, "r", encoding="utf-8") as file:
         prompt_data = json.load(file)
     if mode == 'background':
-        prompt_data["7"]["inputs"]["seed"] = random.randint(1, 1000000)
-        prompt_data["4"]["inputs"]["text"] += prompt
+        prompt_data["5"]["inputs"]["seed"] = random.randint(1, 1000000)
+        prompt_data["5"]["inputs"]["prompt"] += prompt
     if mode == 'character':
         prompt_data["3"]["inputs"]["seed"] = random.randint(1, 1000000)
-        prompt_data["57"]["inputs"]["text"] += prompt
+        prompt_data["3"]["inputs"]["prompt"] += prompt
     result = queue_prompt(prompt_data, ComfyUI_url)
     prompt_id = result.get("prompt_id")
     if not prompt_id:
@@ -120,7 +116,7 @@ def ComfyUI_generate_image(prompt, image_name, mode):
             print("图片下载完成！")
 
             outputs = history[prompt_id].get('outputs', {})
-            output_node = '12' if mode == 'background' else '64'
+            output_node = '7' if mode == 'background' else '10'
             if outputs and output_node in outputs:
                 images = outputs[output_node].get('images', [])
                 for idx, image in enumerate(images):

--- a/script.rpy
+++ b/script.rpy
@@ -54,7 +54,8 @@ init python:
         global ok
         ok = False
         result = gpt_context(f"现在你要扮演以下角色:{system},你的语气应当生动，有自己的情绪，尽量让对话流畅自然。你的话语会让人觉得可爱和有趣，并逐渐展露暖面,语言简短精炼，不要用()", ask, history=history)
-        generate_audio(translate(result), id, "response")
+        if generator.if_generate_audio:
+            generate_audio(translate(result), id, "response")
         result_container.append(result)
         ok = True
 
@@ -132,7 +133,8 @@ label talk_mode:
             $ renpy.pause(0.5, hard=True)
         $ response = response_container[0]
         $ renpy.show(character, at_list=[shake])
-        $ renpy.sound.play("audio/response.wav", channel='sound')
+        if generator.if_generate_audio:
+            $ renpy.sound.play("audio/response.wav", channel='sound')
         $ renpy.say(character, f"『{response}』")
         $ history.append({"role": "assistant", "content": response})
         $ history.append({"role": "user", "content": ask})
@@ -195,7 +197,7 @@ label start:
 
         if character_name not in characters:
             $ characters[character_name] = Character(character_name)
-        if character_name:
+        if character_name and generator.if_generate_audio:
             $ renpy.sound.play(audio, channel='sound')
         # 仅当背景发生变化时才更新
         if background_image and background_image != last_background_image:


### PR DESCRIPTION
本次提交引入了一项新功能，允许用户启用或禁用角色语音的生成和播放。该设置可通过 GUI中“GPT-SOVITS”选项卡下的新开关进行配置，…并会保存到 `config.toml` 文件中。同时修复背景生成原本的正则表达式的些许错误并再次提交上次误操作并未合并的gptsovits的gui配置

主要变更包括：
1. game_generator.py:
    + 新增了配置项 `if_generate_audio`，在初始化时从 `config.toml` 读取。
    + `_process_story_results` 中的音频生成流程现在会根据此设置条件执行。
2. gui.py:
    + 在“GPT-SOVITS”设置页面添加了“启用语音”的 `SwitchSettingCard`，允许用户切换此功能。
    + `start_game`中的启动前检查现在仅在语音被启用且未开启云端模式时，才会校验本地语音服务，避免了不必要的错误。
3. script.rpy:
    + 修改了游戏引擎逻辑，根据 `if_generate_audio`
    + 设置来条件性地播放音频文件。这会影响主线故事对话和互动对话模式。